### PR TITLE
feat: ORM persistence layer

### DIFF
--- a/config/db-schema.js
+++ b/config/db-schema.js
@@ -1,0 +1,10 @@
+import { Model, hasMany } from '@stonyx/orm';
+
+export default class DBModel extends Model {
+  cronJobs = hasMany('cron-job');
+  cronJobSchedules = hasMany('cron-job/schedule');
+  cronJobPayloads = hasMany('cron-job/payload');
+  cronJobStates = hasMany('cron-job/state');
+  cronJobDeliveries = hasMany('cron-job/delivery');
+  cronRuns = hasMany('cron-run');
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,7 @@
-const { CRON_LOG } = process;
+const { CRON_LOG, CRON_PERSISTENCE } = process;
 
 export default {
   log: CRON_LOG ?? true,
   logColor: '#888',
+  persistence: CRON_PERSISTENCE ?? false,
 }

--- a/models/cron-job.js
+++ b/models/cron-job.js
@@ -1,0 +1,17 @@
+import { Model, attr, belongsTo } from '@stonyx/orm';
+
+export default class CronJobModel extends Model {
+  name = attr('string');
+  description = attr('string');
+  enabled = attr('boolean');
+  deleteAfterRun = attr('boolean');
+  sessionTarget = attr('string');
+  wakeMode = attr('string');
+  createdAtMs = attr('number');
+  updatedAtMs = attr('number');
+
+  schedule = belongsTo('cron-job/schedule');
+  payload = belongsTo('cron-job/payload');
+  state = belongsTo('cron-job/state');
+  delivery = belongsTo('cron-job/delivery');
+}

--- a/models/cron-job/delivery.js
+++ b/models/cron-job/delivery.js
@@ -1,0 +1,5 @@
+import { Model, attr } from '@stonyx/orm';
+
+export default class CronJobDeliveryModel extends Model {
+  mode = attr('string');
+}

--- a/models/cron-job/payload.js
+++ b/models/cron-job/payload.js
@@ -1,0 +1,7 @@
+import { Model, attr } from '@stonyx/orm';
+
+export default class CronJobPayloadModel extends Model {
+  kind = attr('string');
+  message = attr('string');
+  text = attr('string');
+}

--- a/models/cron-job/schedule.js
+++ b/models/cron-job/schedule.js
@@ -1,0 +1,10 @@
+import { Model, attr } from '@stonyx/orm';
+
+export default class CronJobScheduleModel extends Model {
+  kind = attr('string');
+  at = attr('string');
+  everyMs = attr('number');
+  anchorMs = attr('number');
+  expr = attr('string');
+  tz = attr('string');
+}

--- a/models/cron-job/state.js
+++ b/models/cron-job/state.js
@@ -1,0 +1,12 @@
+import { Model, attr } from '@stonyx/orm';
+
+export default class CronJobStateModel extends Model {
+  nextRunAtMs = attr('number');
+  runningAtMs = attr('number');
+  lastRunAtMs = attr('number');
+  lastStatus = attr('string');
+  lastError = attr('string');
+  lastDurationMs = attr('number');
+  consecutiveErrors = attr('number');
+  scheduleErrorCount = attr('number');
+}

--- a/models/cron-run.js
+++ b/models/cron-run.js
@@ -1,0 +1,12 @@
+import { Model, attr } from '@stonyx/orm';
+
+export default class CronRunModel extends Model {
+  jobId = attr('string');
+  status = attr('string');
+  error = attr('string');
+  summary = attr('string');
+  runAtMs = attr('number');
+  durationMs = attr('number');
+  nextRunAtMs = attr('number');
+  ts = attr('number');
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@stonyx/cron",
   "keywords": [
-    "stonyx-module"
+    "stonyx-module",
+    "stonyx-async"
   ],
   "version": "0.2.1-beta.24",
   "description": "Cron/job scheduler for Stonyx framework",
@@ -19,7 +20,8 @@
     "./normalize": "./src/normalize.js",
     "./locked": "./src/locked.js",
     "./run-log": "./src/run-log.js",
-    "./min-heap": "./src/min-heap.js"
+    "./min-heap": "./src/min-heap.js",
+    "./persistence": "./src/persistence.js"
   },
   "scripts": {
     "test": "stonyx test",

--- a/serializers/cron-job.js
+++ b/serializers/cron-job.js
@@ -1,0 +1,18 @@
+import { Serializer } from '@stonyx/orm';
+
+export default class CronJobSerializer extends Serializer {
+  map = {
+    name: 'name',
+    description: 'description',
+    enabled: 'enabled',
+    deleteAfterRun: 'deleteAfterRun',
+    sessionTarget: 'sessionTarget',
+    wakeMode: 'wakeMode',
+    createdAtMs: 'createdAtMs',
+    updatedAtMs: 'updatedAtMs',
+    schedule: 'schedule',
+    payload: 'payload',
+    state: 'state',
+    delivery: 'delivery',
+  }
+}

--- a/serializers/cron-job/delivery.js
+++ b/serializers/cron-job/delivery.js
@@ -1,0 +1,7 @@
+import { Serializer } from '@stonyx/orm';
+
+export default class CronJobDeliverySerializer extends Serializer {
+  map = {
+    mode: 'mode',
+  }
+}

--- a/serializers/cron-job/payload.js
+++ b/serializers/cron-job/payload.js
@@ -1,0 +1,9 @@
+import { Serializer } from '@stonyx/orm';
+
+export default class CronJobPayloadSerializer extends Serializer {
+  map = {
+    kind: 'kind',
+    message: 'message',
+    text: 'text',
+  }
+}

--- a/serializers/cron-job/schedule.js
+++ b/serializers/cron-job/schedule.js
@@ -1,0 +1,12 @@
+import { Serializer } from '@stonyx/orm';
+
+export default class CronJobScheduleSerializer extends Serializer {
+  map = {
+    kind: 'kind',
+    at: 'at',
+    everyMs: 'everyMs',
+    anchorMs: 'anchorMs',
+    expr: 'expr',
+    tz: 'tz',
+  }
+}

--- a/serializers/cron-job/state.js
+++ b/serializers/cron-job/state.js
@@ -1,0 +1,14 @@
+import { Serializer } from '@stonyx/orm';
+
+export default class CronJobStateSerializer extends Serializer {
+  map = {
+    nextRunAtMs: 'nextRunAtMs',
+    runningAtMs: 'runningAtMs',
+    lastRunAtMs: 'lastRunAtMs',
+    lastStatus: 'lastStatus',
+    lastError: 'lastError',
+    lastDurationMs: 'lastDurationMs',
+    consecutiveErrors: 'consecutiveErrors',
+    scheduleErrorCount: 'scheduleErrorCount',
+  }
+}

--- a/serializers/cron-run.js
+++ b/serializers/cron-run.js
@@ -1,0 +1,14 @@
+import { Serializer } from '@stonyx/orm';
+
+export default class CronRunSerializer extends Serializer {
+  map = {
+    jobId: 'jobId',
+    status: 'status',
+    error: 'error',
+    summary: 'summary',
+    runAtMs: 'runAtMs',
+    durationMs: 'durationMs',
+    nextRunAtMs: 'nextRunAtMs',
+    ts: 'ts',
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -16,8 +16,11 @@
 
 import config from 'stonyx/config';
 import log from 'stonyx/log';
+import { waitForModule } from 'stonyx';
 import { getTimestamp } from "@stonyx/utils/date";
 import MinHeap from '@stonyx/cron/min-heap';
+import CronService from './service.js';
+import * as persistence from './persistence.js';
 
 export default class Cron {
   jobs = {};
@@ -27,7 +30,31 @@ export default class Cron {
   constructor() {
     if (Cron.instance) return Cron.instance;
     Cron.instance = this;
+    this.service = new CronService();
   }
+
+  async init() {
+    if (config.cron?.persistence) {
+      try {
+        await waitForModule('orm');
+        await persistence.initPersistence();
+        this.service.persist = persistence;
+        this.log('ORM persistence enabled');
+      } catch (err) {
+        log.error('Failed to initialize cron persistence:', err);
+        throw err;
+      }
+    }
+
+    await this.service.start();
+  }
+
+  async shutdown() {
+    this.service.stop();
+    clearTimeout(this.timer);
+  }
+
+  // ── Legacy API (backwards-compatible) ───��─────────────────
 
   scheduleNextRun() {
     clearTimeout(this.timer);
@@ -88,7 +115,7 @@ export default class Cron {
   unregister(key) {
     const { heap, jobs } = this;
     const job = jobs[key];
-    
+
     if (!job) return;
 
     delete jobs[key];
@@ -105,7 +132,7 @@ export default class Cron {
 
   log(text, key = null) {
     if (!config.cron?.log) return;
-    
+
     const tag = key ? `Cron::${key}` : `Cron`;
     log.cron(`${tag} - ${text}:`);
   }

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -1,0 +1,143 @@
+/**
+ * ORM persistence adapter for CronService.
+ *
+ * Bridges the in-memory job model (src/job.js) with @stonyx/orm records.
+ * Only loaded when persistence is configured — ORM is an optional dependency.
+ */
+
+let orm, store, createRecord, updateRecord;
+
+/**
+ * Initialize the persistence layer by importing ORM.
+ * Must be called after ORM module is ready (via waitForModule).
+ */
+export async function initPersistence() {
+  const ormModule = await import('@stonyx/orm');
+  orm = ormModule.default;
+  store = ormModule.store;
+  createRecord = ormModule.createRecord;
+  updateRecord = ormModule.updateRecord;
+}
+
+/**
+ * Convert an in-memory job object to ORM-compatible flat data.
+ */
+function jobToRecord(job) {
+  return {
+    id: job.id,
+    name: job.name,
+    description: job.description,
+    enabled: job.enabled,
+    deleteAfterRun: job.deleteAfterRun,
+    sessionTarget: job.sessionTarget,
+    wakeMode: job.wakeMode,
+    createdAtMs: job.createdAtMs,
+    updatedAtMs: job.updatedAtMs,
+    schedule: { id: job.id, ...job.schedule },
+    payload: { id: job.id, ...job.payload },
+    state: { id: job.id, ...job.state },
+    delivery: job.delivery ? { id: job.id, ...job.delivery } : undefined,
+  };
+}
+
+/**
+ * Convert an ORM record back to an in-memory job object.
+ */
+function recordToJob(record) {
+  const schedule = record.schedule;
+  const payload = record.payload;
+  const state = record.state;
+  const delivery = record.delivery;
+
+  return {
+    id: record.id,
+    name: record.name,
+    description: record.description,
+    enabled: record.enabled,
+    deleteAfterRun: record.deleteAfterRun,
+    sessionTarget: record.sessionTarget,
+    wakeMode: record.wakeMode,
+    createdAtMs: record.createdAtMs,
+    updatedAtMs: record.updatedAtMs,
+    schedule: schedule ? {
+      kind: schedule.kind,
+      at: schedule.at,
+      everyMs: schedule.everyMs,
+      anchorMs: schedule.anchorMs,
+      expr: schedule.expr,
+      tz: schedule.tz,
+    } : undefined,
+    payload: payload ? {
+      kind: payload.kind,
+      message: payload.message,
+      text: payload.text,
+    } : undefined,
+    state: state ? {
+      nextRunAtMs: state.nextRunAtMs,
+      runningAtMs: state.runningAtMs,
+      lastRunAtMs: state.lastRunAtMs,
+      lastStatus: state.lastStatus,
+      lastError: state.lastError,
+      lastDurationMs: state.lastDurationMs,
+      consecutiveErrors: state.consecutiveErrors || 0,
+      scheduleErrorCount: state.scheduleErrorCount || 0,
+    } : {
+      consecutiveErrors: 0,
+      scheduleErrorCount: 0,
+    },
+    delivery: delivery ? { mode: delivery.mode } : undefined,
+  };
+}
+
+/**
+ * Load all persisted cron jobs from the ORM store.
+ * @returns {Array} Array of in-memory job objects
+ */
+export function loadJobs() {
+  const records = store.get('cron-job');
+  if (!records) return [];
+
+  const jobs = [];
+  for (const [, record] of records) {
+    jobs.push(recordToJob(record));
+  }
+  return jobs;
+}
+
+/**
+ * Persist a job to the ORM store (create or update).
+ */
+export function saveJob(job) {
+  const data = jobToRecord(job);
+  const existing = store.get('cron-job', job.id);
+
+  if (existing) {
+    updateRecord(existing, data);
+  } else {
+    createRecord('cron-job', data);
+  }
+}
+
+/**
+ * Remove a job from the ORM store.
+ */
+export function removeJob(id) {
+  store.remove('cron-job', id);
+}
+
+/**
+ * Persist a run log entry.
+ */
+export function saveRun(entry) {
+  createRecord('cron-run', {
+    ...entry,
+    ts: entry.ts || Date.now(),
+  });
+}
+
+/**
+ * Flush all changes to disk.
+ */
+export async function save() {
+  await orm.db.save();
+}

--- a/src/service.js
+++ b/src/service.js
@@ -2,7 +2,7 @@
  * CronService — the main API for advanced job scheduling.
  *
  * Manages jobs in memory with a min-heap for efficient next-job lookup.
- * Supports pluggable store interface (memory-only by default, ORM in PR 2).
+ * Supports optional ORM persistence via a pluggable store adapter.
  * All state mutations are serialized via async locking.
  */
 import config from 'stonyx/config';
@@ -27,6 +27,9 @@ export default class CronService {
 
     // Pluggable callbacks for consumers
     this.onJobDue = null;        // async (job) => { status, error?, summary? }
+
+    // Optional persistence adapter: { loadJobs, saveJob, removeJob, saveRun, save }
+    this.persist = null;
   }
 
   // ── Lifecycle ──────────────────────────────────────────────
@@ -38,8 +41,11 @@ export default class CronService {
     if (this.started) return;
     this.started = true;
 
-    if (initialJobs) {
-      for (const job of initialJobs) {
+    // Load from persistence if available and no explicit initialJobs
+    const jobs = initialJobs || (this.persist ? this.persist.loadJobs() : null);
+
+    if (jobs) {
+      for (const job of jobs) {
         this.jobs.set(job.id, job);
         if (job.enabled && job.state.nextRunAtMs) {
           this.heap.push({ key: job.id, nextTrigger: job.state.nextRunAtMs });
@@ -94,7 +100,7 @@ export default class CronService {
    * Add a new job. Input is normalized for AI compatibility.
    */
   async add(rawInput) {
-    return locked(() => {
+    return locked(async () => {
       const input = normalizeJobInput(recoverFlatParams(rawInput));
       const job = createJob(input);
       this.jobs.set(job.id, job);
@@ -102,6 +108,11 @@ export default class CronService {
       if (job.enabled && job.state.nextRunAtMs) {
         this.heap.push({ key: job.id, nextTrigger: job.state.nextRunAtMs });
         this.armTimer();
+      }
+
+      if (this.persist) {
+        this.persist.saveJob(job);
+        await this.persist.save();
       }
 
       return job;
@@ -112,7 +123,7 @@ export default class CronService {
    * Update an existing job.
    */
   async update(id, patch) {
-    return locked(() => {
+    return locked(async () => {
       const job = this.jobs.get(id);
       if (!job) throw new Error(`Job not found: ${id}`);
 
@@ -129,6 +140,11 @@ export default class CronService {
         this.armTimer();
       }
 
+      if (this.persist) {
+        this.persist.saveJob(job);
+        await this.persist.save();
+      }
+
       return job;
     });
   }
@@ -137,7 +153,7 @@ export default class CronService {
    * Remove a job.
    */
   async remove(id) {
-    return locked(() => {
+    return locked(async () => {
       const job = this.jobs.get(id);
       if (!job) throw new Error(`Job not found: ${id}`);
 
@@ -145,6 +161,11 @@ export default class CronService {
       this.removeFromHeap(id);
       this.runLog.removeJob(id);
       this.armTimer();
+
+      if (this.persist) {
+        this.persist.removeJob(id);
+        await this.persist.save();
+      }
     });
   }
 
@@ -266,16 +287,31 @@ export default class CronService {
       nextRunAtMs: job.state.nextRunAtMs,
     });
 
+    // Persist run log and updated job state
+    if (this.persist) {
+      this.persist.saveRun({ jobId: job.id, status, error, summary, runAtMs: startMs, durationMs });
+    }
+
     // Handle one-shot auto-delete
     if (job.deleteAfterRun && status === 'ok' && !job.enabled) {
       this.jobs.delete(job.id);
       this.runLog.removeJob(job.id);
+      if (this.persist) {
+        this.persist.removeJob(job.id);
+        await this.persist.save();
+      }
       return { status, summary, deleted: true };
     }
 
     // Re-insert into heap if still active
     if (job.enabled && job.state.nextRunAtMs) {
       this.heap.push({ key: job.id, nextTrigger: job.state.nextRunAtMs });
+    }
+
+    // Persist updated job state
+    if (this.persist) {
+      this.persist.saveJob(job);
+      await this.persist.save();
     }
 
     return { status, error, summary, durationMs };
@@ -298,6 +334,8 @@ export default class CronService {
 
   log(message) {
     if (!config.cron?.log) return;
-    log.cron(`Cron — ${message}`);
+    if (typeof log.cron === 'function') {
+      log.cron(`Cron — ${message}`);
+    }
   }
 }

--- a/test/unit/persistence-test.js
+++ b/test/unit/persistence-test.js
@@ -1,0 +1,196 @@
+import QUnit from 'qunit';
+import sinon from 'sinon';
+const { module, test } = QUnit;
+import { setupIntegrationTests } from 'stonyx/test-helpers';
+import CronService from '../../src/service.js';
+import { resetLock } from '../../src/locked.js';
+
+module('CronService persistence', function (hooks) {
+  setupIntegrationTests(hooks);
+  let service;
+  let clock;
+  let mockPersist;
+
+  hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers({ shouldAdvanceTime: false, now: new Date('2026-06-15T12:00:00Z') });
+
+    mockPersist = {
+      loadJobs: sinon.stub().returns([]),
+      saveJob: sinon.stub(),
+      removeJob: sinon.stub(),
+      saveRun: sinon.stub(),
+      save: sinon.stub().resolves(),
+    };
+
+    service = new CronService();
+    service.persist = mockPersist;
+  });
+
+  hooks.afterEach(function () {
+    service.stop();
+    clock.restore();
+    resetLock();
+  });
+
+  module('start', function () {
+    test('loads jobs from persistence on start', async function (assert) {
+      mockPersist.loadJobs.returns([
+        {
+          id: 'persisted-1',
+          name: 'Saved Job',
+          enabled: true,
+          schedule: { kind: 'every', everyMs: 60_000 },
+          payload: { kind: 'agentTurn', message: 'hi' },
+          state: { nextRunAtMs: Date.now() + 30_000, consecutiveErrors: 0 },
+        },
+      ]);
+
+      await service.start();
+      assert.strictEqual(service.status().jobCount, 1);
+      assert.strictEqual(service.get('persisted-1').name, 'Saved Job');
+    });
+
+    test('prefers explicit initialJobs over persistence', async function (assert) {
+      mockPersist.loadJobs.returns([
+        { id: 'from-store', name: 'Store', enabled: true, schedule: { kind: 'every', everyMs: 60_000 }, payload: { kind: 'agentTurn', message: 'hi' }, state: { nextRunAtMs: Date.now() + 30_000, consecutiveErrors: 0 } },
+      ]);
+
+      await service.start([
+        { id: 'explicit', name: 'Explicit', enabled: true, schedule: { kind: 'every', everyMs: 60_000 }, payload: { kind: 'agentTurn', message: 'hi' }, state: { nextRunAtMs: Date.now() + 30_000, consecutiveErrors: 0 } },
+      ]);
+
+      assert.strictEqual(service.status().jobCount, 1);
+      assert.ok(service.get('explicit'));
+      assert.strictEqual(service.get('from-store'), null);
+    });
+  });
+
+  module('add', function () {
+    test('persists new job', async function (assert) {
+      await service.start();
+      const job = await service.add({
+        name: 'New Job',
+        schedule: { kind: 'every', everyMs: 60_000 },
+        payload: { kind: 'agentTurn', message: 'go' },
+      });
+
+      assert.ok(mockPersist.saveJob.calledOnce);
+      assert.strictEqual(mockPersist.saveJob.firstCall.args[0].id, job.id);
+      assert.ok(mockPersist.save.called);
+    });
+  });
+
+  module('update', function () {
+    test('persists updated job', async function (assert) {
+      await service.start();
+      const job = await service.add({
+        name: 'Original',
+        schedule: { kind: 'every', everyMs: 60_000 },
+        payload: { kind: 'agentTurn', message: 'go' },
+      });
+
+      mockPersist.saveJob.resetHistory();
+      mockPersist.save.resetHistory();
+
+      await service.update(job.id, { name: 'Updated' });
+
+      assert.ok(mockPersist.saveJob.calledOnce);
+      assert.strictEqual(mockPersist.saveJob.firstCall.args[0].name, 'Updated');
+      assert.ok(mockPersist.save.called);
+    });
+  });
+
+  module('remove', function () {
+    test('removes from persistence', async function (assert) {
+      await service.start();
+      const job = await service.add({
+        name: 'Doomed',
+        schedule: { kind: 'every', everyMs: 60_000 },
+        payload: { kind: 'agentTurn', message: 'go' },
+      });
+
+      mockPersist.removeJob.resetHistory();
+      mockPersist.save.resetHistory();
+
+      await service.remove(job.id);
+
+      assert.ok(mockPersist.removeJob.calledOnce);
+      assert.strictEqual(mockPersist.removeJob.firstCall.args[0], job.id);
+      assert.ok(mockPersist.save.called);
+    });
+  });
+
+  module('execution', function () {
+    test('persists run log entry after execution', async function (assert) {
+      service.onJobDue = () => ({ status: 'ok', summary: 'done' });
+
+      await service.start();
+      const job = await service.add({
+        name: 'Runner',
+        schedule: { kind: 'every', everyMs: 60_000 },
+        payload: { kind: 'agentTurn', message: 'go' },
+      });
+
+      mockPersist.saveRun.resetHistory();
+      await service.run(job.id);
+
+      assert.ok(mockPersist.saveRun.calledOnce);
+      const entry = mockPersist.saveRun.firstCall.args[0];
+      assert.strictEqual(entry.jobId, job.id);
+      assert.strictEqual(entry.status, 'ok');
+    });
+
+    test('persists job state after execution', async function (assert) {
+      service.onJobDue = () => ({ status: 'ok' });
+
+      await service.start();
+      const job = await service.add({
+        name: 'Stateful',
+        schedule: { kind: 'every', everyMs: 60_000 },
+        payload: { kind: 'agentTurn', message: 'go' },
+      });
+
+      mockPersist.saveJob.resetHistory();
+      await service.run(job.id);
+
+      assert.ok(mockPersist.saveJob.called);
+    });
+
+    test('persists removal on one-shot deleteAfterRun', async function (assert) {
+      service.onJobDue = () => ({ status: 'ok' });
+
+      await service.start();
+      const future = new Date(Date.now() + 60_000).toISOString();
+      const job = await service.add({
+        name: 'Once',
+        schedule: { kind: 'at', at: future },
+        payload: { kind: 'agentTurn', message: 'go' },
+        deleteAfterRun: true,
+      });
+
+      mockPersist.removeJob.resetHistory();
+      const result = await service.run(job.id);
+
+      assert.strictEqual(result.deleted, true);
+      assert.ok(mockPersist.removeJob.calledOnce);
+    });
+  });
+
+  module('without persistence', function () {
+    test('works normally when persist is null', async function (assert) {
+      service.persist = null;
+      await service.start();
+      const job = await service.add({
+        name: 'No Persist',
+        schedule: { kind: 'every', everyMs: 60_000 },
+        payload: { kind: 'agentTurn', message: 'go' },
+      });
+
+      assert.ok(job.id);
+      await service.update(job.id, { name: 'Still Works' });
+      assert.strictEqual(service.get(job.id).name, 'Still Works');
+      await service.remove(job.id);
+      assert.strictEqual(service.get(job.id), null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add ORM models for cron-job (with schedule/payload/state/delivery sub-models) and cron-run
- Add serializers (identity mappings) for all models
- Add DB schema (`config/db-schema.js`) with all collections
- Add persistence adapter (`src/persistence.js`): loadJobs, saveJob, removeJob, saveRun, save
- Wire CronService with pluggable `persist` adapter — auto-loads from store on start, persists on all mutations
- Add `init()`/`shutdown()` lifecycle to main module with `waitForModule('orm')` when persistence configured
- Add `persistence` config flag (default: false) — ORM is fully optional

## Test plan

- [x] 9 new persistence tests using mocked adapter (load, add, update, remove, execution, one-shot delete, no-persist fallback)
- [x] 126 total tests passing (9 new + 117 existing)
- [x] All existing tests pass without ORM installed (optional dep verified)

Stacked on #1 (`feat/advanced-scheduling`).
Ref: mstonepc/trix#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)