### PR TITLE
fix: add explicit files whitelist for npm publish safety

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,10 @@
-# tests
-test/
-
-# config
-.nvmrc
-# git
 .git
+.env
+.npmrc
+.claude/
+.github/
+test/
+scripts/
+*.log
+.nvmrc
+.gitignore

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "main": "src/main.js",
   "type": "module",
   "files": [
-    "*"
+    "src",
+    "config",
+    "README.md"
   ],
   "exports": {
     ".": "./src/main.js",


### PR DESCRIPTION
## Summary
- Replace the dangerous `"files": ["*"]` wildcard in `package.json` with an explicit whitelist: `["src", "config", "README.md"]`
- Update `.npmignore` with comprehensive exclusions (`.git`, `.env`, `.npmrc`, `.claude/`, `.github/`, `test/`, `scripts/`, `*.log`, `.nvmrc`, `.gitignore`)
- Verified with `npm pack --dry-run` that only safe files (src/, config/, README.md, LICENSE.md, package.json) are included in the tarball

Closes #9

## Test plan
- [x] `npm pack --dry-run` confirms only intended files are packaged (13 files, 16.0 kB)
- [ ] Verify no `.git/`, `.env`, or test files appear in published package

🤖 Generated with [Claude Code](https://claude.com/claude-code)