### PR TITLE
ci: add dev branch to publish workflow triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ on:
         type: string
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main]
+    branches: [dev, main]
   push:
-    branches: [main]
+    branches: [dev, main]
 
 concurrency:
   group: ${{ github.event_name == 'repository_dispatch' && 'cascade-update' || format('publish-{0}', github.ref) }}


### PR DESCRIPTION
## Summary
- Add `dev` to `pull_request.branches` and `push.branches` in publish workflow
- Enables the new branch-based release channel model where `dev` = beta and `main` = stable
- Depends on [stonyx-workflows#7](https://github.com/abofs/stonyx-workflows/pull/7) being merged first

## Test plan
- [ ] Verify stonyx-workflows PR merges first
- [ ] After merge, create `dev` branch from `main` and set as default
- [ ] Confirm PR to dev triggers alpha publish
- [ ] Confirm push to dev triggers beta publish
- [ ] Confirm push to main triggers stable publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)