### PR TITLE
feat: migrate to TypeScript with strict mode

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,13 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    uses: abofs/stonyx-workflows/.github/workflows/security-audit.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,9 @@ config/environment.js
 *.vsix%
 *DS_Store*
 
+# build output
+dist/
+dist-test/
+
 # npm auth (never commit tokens)
 .npmrc

--- a/package.json
+++ b/package.json
@@ -5,26 +5,56 @@
   ],
   "version": "0.2.1-beta.31",
   "description": "Cron/job scheduler for Stonyx framework",
-  "main": "src/main.js",
+  "main": "dist/main.js",
+  "types": "dist/main.d.ts",
   "type": "module",
   "files": [
-    "src",
+    "dist",
     "config",
     "README.md"
   ],
   "exports": {
-    ".": "./src/main.js",
-    "./service": "./src/service.js",
-    "./cron-parser": "./src/cron-parser.js",
-    "./schedule": "./src/schedule.js",
-    "./job": "./src/job.js",
-    "./normalize": "./src/normalize.js",
-    "./locked": "./src/locked.js",
-    "./run-log": "./src/run-log.js",
-    "./min-heap": "./src/min-heap.js"
+    ".": {
+      "types": "./dist/main.d.ts",
+      "default": "./dist/main.js"
+    },
+    "./service": {
+      "types": "./dist/service.d.ts",
+      "default": "./dist/service.js"
+    },
+    "./cron-parser": {
+      "types": "./dist/cron-parser.d.ts",
+      "default": "./dist/cron-parser.js"
+    },
+    "./schedule": {
+      "types": "./dist/schedule.d.ts",
+      "default": "./dist/schedule.js"
+    },
+    "./job": {
+      "types": "./dist/job.d.ts",
+      "default": "./dist/job.js"
+    },
+    "./normalize": {
+      "types": "./dist/normalize.d.ts",
+      "default": "./dist/normalize.js"
+    },
+    "./locked": {
+      "types": "./dist/locked.d.ts",
+      "default": "./dist/locked.js"
+    },
+    "./run-log": {
+      "types": "./dist/run-log.d.ts",
+      "default": "./dist/run-log.js"
+    },
+    "./min-heap": {
+      "types": "./dist/min-heap.d.ts",
+      "default": "./dist/min-heap.js"
+    }
   },
   "scripts": {
-    "test": "stonyx test",
+    "build": "tsc",
+    "build:test": "tsc -p tsconfig.test.json",
+    "test": "pnpm build && pnpm build:test && stonyx test 'dist-test/test/**/*-test.js'",
     "prepublishOnly": "npm test"
   },
   "publishConfig": {
@@ -46,8 +76,10 @@
   "homepage": "https://github.com/abofs/stonyx-cron#readme",
   "devDependencies": {
     "@stonyx/utils": "0.2.3-beta.7",
+    "@types/node": "^25.5.2",
     "qunit": "^2.24.1",
-    "sinon": "^21.0.0"
+    "sinon": "^21.0.0",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "stonyx": "0.2.3-beta.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,12 +15,18 @@ importers:
       '@stonyx/utils':
         specifier: 0.2.3-beta.7
         version: 0.2.3-beta.7
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
       qunit:
-        specifier: ^2.25.0
+        specifier: ^2.24.1
         version: 2.25.0
       sinon:
-        specifier: ^21.0.3
+        specifier: ^21.0.0
         version: 21.0.3
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
 
 packages:
 
@@ -35,6 +41,9 @@ packages:
 
   '@stonyx/utils@0.2.3-beta.7':
     resolution: {integrity: sha512-SF6ZZZJ/f1n/+SJJDj8BJdlgvv+WDLGWGUMIkwTpruA5jv/AYJqSoVIgTpYfuMTnYDIsp3KoruaIKy/qd2ETPQ==}
+
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -183,6 +192,14 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
@@ -206,6 +223,10 @@ snapshots:
       type-detect: 4.1.0
 
   '@stonyx/utils@0.2.3-beta.7': {}
+
+  '@types/node@25.5.2':
+    dependencies:
+      undici-types: 7.18.2
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -360,6 +381,10 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-detect@4.1.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
 
   url@0.11.4:
     dependencies:

--- a/src/cron-parser.ts
+++ b/src/cron-parser.ts
@@ -1,15 +1,28 @@
 /**
  * 5-field cron expression parser with next-occurrence computation.
- * No external dependencies — built for stonyx-cron.
+ * No external dependencies - built for stonyx-cron.
  *
  * Fields: minute(0-59) hour(0-23) day-of-month(1-31) month(1-12) day-of-week(0-6)
  * Supports: wildcards(*), ranges(1-5), steps(* /5), lists(1,3,5), names(jan-dec, sun-sat)
  */
 
-const MONTH_NAMES = { jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6, jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12 };
-const DAY_NAMES = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
+interface FieldRange {
+  min: number;
+  max: number;
+}
 
-const FIELD_RANGES = [
+export interface ParsedCronExpression {
+  minutes: number[];
+  hours: number[];
+  daysOfMonth: number[];
+  months: number[];
+  daysOfWeek: number[];
+}
+
+const MONTH_NAMES: Record<string, number> = { jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6, jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12 };
+const DAY_NAMES: Record<string, number> = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
+
+const FIELD_RANGES: FieldRange[] = [
   { min: 0, max: 59 },  // minute
   { min: 0, max: 23 },  // hour
   { min: 1, max: 31 },  // day of month
@@ -19,27 +32,24 @@ const FIELD_RANGES = [
 
 /**
  * Parse a single cron field into a sorted array of allowed values.
- * @param {string} field - The field string (e.g., "1-5", "* /15", "mon,wed,fri")
- * @param {number} fieldIndex - Index (0=minute, 1=hour, 2=dom, 3=month, 4=dow)
- * @returns {number[]} Sorted array of allowed integer values
  */
-export function parseField(field, fieldIndex) {
+export function parseField(field: string, fieldIndex: number): number[] {
   const { min, max } = FIELD_RANGES[fieldIndex];
   const names = fieldIndex === 3 ? MONTH_NAMES : fieldIndex === 4 ? DAY_NAMES : null;
 
-  const resolveToken = (token) => {
+  const resolveToken = (token: string): number => {
     if (names) {
       const lower = token.toLowerCase();
       if (lower in names) return names[lower];
     }
     const n = Number(token);
     if (!Number.isInteger(n)) throw new Error(`Invalid cron value: "${token}" in field ${fieldIndex}`);
-    // Normalize day-of-week 7 → 0 (both mean Sunday)
+    // Normalize day-of-week 7 -> 0 (both mean Sunday)
     if (fieldIndex === 4 && n === 7) return 0;
     return n;
   };
 
-  const results = new Set();
+  const results = new Set<number>();
 
   for (const part of field.split(',')) {
     const trimmed = part.trim();
@@ -50,7 +60,7 @@ export function parseField(field, fieldIndex) {
       throw new Error(`Invalid step "${stepStr}" in cron field ${fieldIndex}`);
     }
 
-    let start, end;
+    let start: number, end: number;
 
     if (rangeStr === '*') {
       start = min;
@@ -78,10 +88,8 @@ export function parseField(field, fieldIndex) {
 
 /**
  * Parse a 5-field cron expression into field arrays.
- * @param {string} expr - Cron expression (e.g., "0 9 * * 1-5")
- * @returns {{ minutes: number[], hours: number[], daysOfMonth: number[], months: number[], daysOfWeek: number[] }}
  */
-export function parseCronExpression(expr) {
+export function parseCronExpression(expr: string): ParsedCronExpression {
   const fields = expr.trim().split(/\s+/);
   if (fields.length !== 5) {
     throw new Error(`Cron expression must have exactly 5 fields, got ${fields.length}: "${expr}"`);
@@ -99,36 +107,27 @@ export function parseCronExpression(expr) {
 /**
  * Get the number of days in a given month/year.
  */
-function daysInMonth(year, month) {
-  return new Date(year, month, 0).getDate();
+function daysInMonth(_year: number, month: number): number {
+  return new Date(_year, month, 0).getDate();
 }
 
 /**
  * Check if a day-of-month + day-of-week pair matches the parsed expression.
- *
- * Standard cron behavior: if BOTH dom and dow are restricted (not *),
- * then EITHER matching is sufficient (OR logic).
- * If only one is restricted, it acts as the sole filter.
  */
-function dayMatches(parsed, domWild, dowWild, dayOfMonth, dayOfWeek) {
+function dayMatches(parsed: ParsedCronExpression, domWild: boolean, dowWild: boolean, dayOfMonth: number, dayOfWeek: number): boolean {
   const domMatch = parsed.daysOfMonth.includes(dayOfMonth);
   const dowMatch = parsed.daysOfWeek.includes(dayOfWeek);
 
   if (domWild && dowWild) return true;
   if (domWild) return dowMatch;
   if (dowWild) return domMatch;
-  return domMatch || dowMatch; // Both restricted → OR
+  return domMatch || dowMatch; // Both restricted -> OR
 }
 
 /**
  * Compute the next occurrence of a cron expression after a given timestamp.
- *
- * @param {string} expr - 5-field cron expression
- * @param {number} afterMs - Timestamp in milliseconds (exclusive — finds strictly after this)
- * @param {string} [tz] - IANA timezone (defaults to system timezone)
- * @returns {number|undefined} Next occurrence in milliseconds, or undefined if none within 4 years
  */
-export function nextOccurrence(expr, afterMs, tz) {
+export function nextOccurrence(expr: string, afterMs: number, tz?: string): number | undefined {
   const parsed = parseCronExpression(expr);
   const exprFields = expr.trim().split(/\s+/);
   const domWild = exprFields[2] === '*';
@@ -147,11 +146,11 @@ export function nextOccurrence(expr, afterMs, tz) {
     weekday: 'short',
   });
 
-  const dayMap = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  const dayMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
 
   // Parse formatted date parts in the target timezone
-  function getLocalParts(date) {
-    const parts = {};
+  function getLocalParts(date: Date): { year: number; month: number; day: number; hour: number; minute: number; weekday: number } {
+    const parts: Record<string, string> = {};
     for (const { type, value } of formatter.formatToParts(date)) {
       parts[type] = value;
     }
@@ -165,23 +164,20 @@ export function nextOccurrence(expr, afterMs, tz) {
     };
   }
 
-  // Search limit: 4 years of minutes (≈ 2.1M iterations max)
+  // Search limit: 4 years of minutes
   const maxMs = afterMs + 4 * 365.25 * 24 * 60 * 60 * 1000;
-  let candidate = new Date(startDate);
+  const candidate = new Date(startDate);
 
   while (candidate.getTime() <= maxMs) {
     const p = getLocalParts(candidate);
 
     // Check month
     if (!parsed.months.includes(p.month)) {
-      // Advance to next matching month
       const nextMonth = parsed.months.find(m => m > p.month);
       if (nextMonth) {
-        // Stay in same year, advance to first day of nextMonth
-        candidate = advanceToMonth(candidate, p.year, nextMonth, tz, formatter, dayMap);
+        advanceToMonth(candidate, p.year, nextMonth);
       } else {
-        // Wrap to next year, first matching month
-        candidate = advanceToMonth(candidate, p.year + 1, parsed.months[0], tz, formatter, dayMap);
+        advanceToMonth(candidate, p.year + 1, parsed.months[0]);
       }
       continue;
     }
@@ -198,7 +194,6 @@ export function nextOccurrence(expr, afterMs, tz) {
       if (nextHour) {
         candidate.setMinutes(candidate.getMinutes() + ((nextHour - p.hour) * 60 - p.minute));
       } else {
-        // Advance to next day
         candidate.setMinutes(candidate.getMinutes() + ((24 - p.hour) * 60 - p.minute));
       }
       continue;
@@ -210,7 +205,6 @@ export function nextOccurrence(expr, afterMs, tz) {
       if (nextMin) {
         candidate.setMinutes(candidate.getMinutes() + (nextMin - p.minute));
       } else {
-        // Advance to next hour
         candidate.setMinutes(candidate.getMinutes() + (60 - p.minute));
       }
       continue;
@@ -224,23 +218,16 @@ export function nextOccurrence(expr, afterMs, tz) {
 }
 
 /**
- * Create a Date advanced to the start of a specific month in a specific year,
- * using the target timezone's midnight.
+ * Advance a Date to the start of a specific month in a specific year.
  */
-function advanceToMonth(current, year, month, tz, formatter, dayMap) {
-  // Create a new date at ~start of the target month in UTC, then adjust
-  const d = new Date(current);
-  // Jump to approximately the right time
-  d.setFullYear(year, month - 1, 1);
-  d.setHours(0, 0, 0, 0);
-  return d;
+function advanceToMonth(current: Date, year: number, month: number): void {
+  current.setFullYear(year, month - 1, 1);
+  current.setHours(0, 0, 0, 0);
 }
 
 /**
  * Validate a cron expression without computing next occurrence.
- * @param {string} expr - 5-field cron expression
- * @throws {Error} if the expression is invalid
  */
-export function validateCronExpression(expr) {
+export function validateCronExpression(expr: string): void {
   parseCronExpression(expr);
 }

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,7 +1,7 @@
 /**
  * Job data model and state machine for the advanced scheduling system.
  */
-import { computeNextRunAtMs, validateSchedule } from './schedule.js';
+import { computeNextRunAtMs, validateSchedule, type Schedule } from './schedule.js';
 
 /**
  * Error backoff table (milliseconds).
@@ -9,34 +9,73 @@ import { computeNextRunAtMs, validateSchedule } from './schedule.js';
  */
 const ERROR_BACKOFF_MS = [30_000, 60_000, 300_000, 900_000, 3_600_000];
 
-export function errorBackoffMs(consecutiveErrors) {
+export interface JobState {
+  nextRunAtMs: number | undefined;
+  runningAtMs: number | undefined;
+  lastRunAtMs: number | undefined;
+  lastStatus: 'ok' | 'error' | 'skipped' | undefined;
+  lastError: string | undefined;
+  lastDurationMs: number | undefined;
+  consecutiveErrors: number;
+  scheduleErrorCount: number;
+}
+
+export interface Job {
+  id: string;
+  name: string;
+  description: string | undefined;
+  enabled: boolean;
+  deleteAfterRun: boolean;
+  createdAtMs: number;
+  updatedAtMs: number;
+  schedule: Schedule;
+  sessionTarget: string;
+  wakeMode: string;
+  payload: Record<string, unknown>;
+  delivery: Record<string, unknown> | undefined;
+  state: JobState;
+}
+
+export interface JobInput {
+  name: string;
+  schedule: Schedule;
+  payload: Record<string, unknown>;
+  description?: string;
+  enabled?: boolean;
+  deleteAfterRun?: boolean;
+  sessionTarget?: string;
+  wakeMode?: string;
+  delivery?: Record<string, unknown>;
+}
+
+export interface JobPatch {
+  name?: string;
+  description?: string;
+  schedule?: Schedule;
+  payload?: Record<string, unknown>;
+  delivery?: Record<string, unknown> | null;
+  enabled?: boolean;
+  deleteAfterRun?: boolean;
+  sessionTarget?: string;
+  wakeMode?: string;
+}
+
+export function errorBackoffMs(consecutiveErrors: number): number {
   if (consecutiveErrors < 1) return 0;
   return ERROR_BACKOFF_MS[Math.min(consecutiveErrors - 1, ERROR_BACKOFF_MS.length - 1)];
 }
 
 /**
  * Create a new job object from input.
- *
- * @param {object} input - Job creation input
- * @param {string} input.name - Job name
- * @param {object} input.schedule - Schedule definition (at/every/cron)
- * @param {object} input.payload - What to execute
- * @param {string} [input.description]
- * @param {boolean} [input.enabled=true]
- * @param {boolean} [input.deleteAfterRun=false]
- * @param {string} [input.sessionTarget="isolated"]
- * @param {string} [input.wakeMode="now"]
- * @param {object} [input.delivery]
- * @returns {object} Complete job object with state
  */
-export function createJob(input) {
+export function createJob(input: JobInput): Job {
   validateSchedule(input.schedule);
 
   const nowMs = Date.now();
   const enabled = input.enabled !== false;
   const deleteAfterRun = input.deleteAfterRun ?? (input.schedule.kind === 'at');
 
-  const job = {
+  const job: Job = {
     id: crypto.randomUUID(),
     name: input.name,
     description: input.description || undefined,
@@ -75,12 +114,8 @@ export function createJob(input) {
 
 /**
  * Apply an update patch to a job.
- *
- * @param {object} job - Existing job
- * @param {object} patch - Fields to update
- * @returns {object} Updated job (same reference, mutated)
  */
-export function updateJob(job, patch) {
+export function updateJob(job: Job, patch: JobPatch): Job {
   const nowMs = Date.now();
 
   if (patch.name !== undefined) job.name = patch.name;
@@ -126,19 +161,14 @@ export function updateJob(job, patch) {
 /**
  * Mark a job as started (running).
  */
-export function markRunning(job) {
+export function markRunning(job: Job): void {
   job.state.runningAtMs = Date.now();
 }
 
 /**
  * Apply the result of a job execution.
- *
- * @param {object} job - The job
- * @param {"ok"|"error"|"skipped"} status - Execution result
- * @param {string} [error] - Error message if status is "error"
- * @param {number} [durationMs] - Execution duration
  */
-export function applyResult(job, status, error, durationMs) {
+export function applyResult(job: Job, status: 'ok' | 'error' | 'skipped', error?: string, durationMs?: number): void {
   const nowMs = Date.now();
 
   job.state.lastRunAtMs = job.state.runningAtMs || nowMs;
@@ -192,7 +222,7 @@ export function applyResult(job, status, error, durationMs) {
 /**
  * Check if a job is due to run.
  */
-export function isDue(job, nowMs) {
+export function isDue(job: Job, nowMs: number): boolean {
   return job.enabled
     && !job.state.runningAtMs
     && job.state.nextRunAtMs !== undefined

--- a/src/locked.ts
+++ b/src/locked.ts
@@ -3,19 +3,16 @@
  * Prevents concurrent operations from corrupting job state.
  */
 
-let chain = Promise.resolve();
+let chain: Promise<void> = Promise.resolve();
 
 /**
  * Execute a function with exclusive access to cron state.
- * Operations queue behind each other — no concurrent mutations.
- *
- * @param {Function} fn - Async function to execute under lock
- * @returns {Promise<*>} Result of fn
+ * Operations queue behind each other - no concurrent mutations.
  */
-export async function locked(fn) {
-  let resolve;
+export async function locked<T>(fn: () => T | Promise<T>): Promise<T> {
+  let resolve!: () => void;
   const prev = chain;
-  chain = new Promise(r => { resolve = r; });
+  chain = new Promise<void>(r => { resolve = r; });
 
   await prev;
 
@@ -29,6 +26,6 @@ export async function locked(fn) {
 /**
  * Reset the lock chain. Only for testing.
  */
-export function resetLock() {
+export function resetLock(): void {
   chain = Promise.resolve();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,40 +16,48 @@
 
 import config from 'stonyx/config';
 import log from 'stonyx/log';
-import { getTimestamp } from "@stonyx/utils/date";
-import MinHeap from '@stonyx/cron/min-heap';
+import { getTimestamp } from '@stonyx/utils/date';
+import MinHeap, { type HeapItem } from './min-heap.js';
+
+interface CronJob extends HeapItem {
+  callback: () => void | Promise<void>;
+  interval: string;
+  key: string;
+}
 
 export default class Cron {
-  jobs = {};
-  heap = new MinHeap();
-  timer = null;
+  static instance: Cron | null;
+
+  jobs: Record<string, CronJob> = {};
+  heap: MinHeap<CronJob> = new MinHeap();
+  timer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     if (Cron.instance) return Cron.instance;
     Cron.instance = this;
   }
 
-  scheduleNextRun() {
-    clearTimeout(this.timer);
+  scheduleNextRun(): void {
+    if (this.timer) clearTimeout(this.timer);
 
     const { heap } = this;
 
     if (heap.isEmpty()) return;
 
-    const nextJob = heap.peek();
+    const nextJob = heap.peek()!;
     const delay = Math.max(0, nextJob.nextTrigger - getTimestamp()) * 1000;
 
     this.timer = setTimeout(() => this.runDueJobs(), delay);
   }
 
-  async runDueJobs() {
+  async runDueJobs(): Promise<void> {
     const now = getTimestamp();
     const { heap } = this;
 
-    while (!heap.isEmpty() && heap.peek().nextTrigger <= now) {
-      const job = heap.pop();
+    while (!heap.isEmpty() && heap.peek()!.nextTrigger <= now) {
+      const job = heap.pop()!;
 
-      if (config.debug) this.log('job has been triggered', job.key);
+      if ((config as Record<string, unknown>).debug) this.log('job has been triggered', job.key);
 
       try {
         await job.callback();
@@ -64,13 +72,13 @@ export default class Cron {
     this.scheduleNextRun();
   }
 
-  register(key, callback, interval, runOnInit=false) {
-    const job = { callback, interval, key };
+  register(key: string, callback: () => void | Promise<void>, interval: string, runOnInit: boolean = false): void {
+    const job: CronJob = { callback, interval, key, nextTrigger: 0 };
     this.jobs[key] = job;
     this.setNextTrigger(job);
     this.heap.push(job);
 
-    if (config.debug) {
+    if ((config as Record<string, unknown>).debug) {
       this.log(`job has been registered with interval: ${interval}`, key);
     }
 
@@ -85,27 +93,27 @@ export default class Cron {
     this.scheduleNextRun();
   }
 
-  unregister(key) {
+  unregister(key: string): void {
     const { heap, jobs } = this;
     const job = jobs[key];
-    
+
     if (!job) return;
 
     delete jobs[key];
     heap.remove(job);
 
-    if (config.debug) this.log('job has been unregistered', key);
+    if ((config as Record<string, unknown>).debug) this.log('job has been unregistered', key);
 
     this.scheduleNextRun();
   }
 
-  setNextTrigger(job) {
+  setNextTrigger(job: CronJob): void {
     job.nextTrigger = getTimestamp() + parseInt(job.interval, 10);
   }
 
-  log(text, key = null) {
-    if (!config.cron?.log) return;
-    
+  log(text: string, key: string | null = null): void {
+    if (!(config as Record<string, Record<string, unknown>>).cron?.log) return;
+
     const tag = key ? `Cron::${key}` : `Cron`;
     log.cron(`${tag} - ${text}:`);
   }

--- a/src/min-heap.ts
+++ b/src/min-heap.ts
@@ -1,26 +1,28 @@
-export default class MinHeap {
-  constructor() {
-    this.items = [];
-  }
+export interface HeapItem {
+  nextTrigger: number;
+}
 
-  push(job) {
+export default class MinHeap<T extends HeapItem> {
+  items: T[] = [];
+
+  push(job: T): void {
     this.items.push(job);
     this.bubbleUp();
   }
 
-  pop() {
+  pop(): T | undefined {
     if (this.items.length === 1) return this.items.pop();
     const top = this.items[0];
-    this.items[0] = this.items.pop();
+    this.items[0] = this.items.pop()!;
     this.bubbleDown();
     return top;
   }
 
-  peek() {
+  peek(): T | undefined {
     return this.items[0];
   }
 
-  bubbleUp() {
+  bubbleUp(): void {
     let idx = this.items.length - 1;
     while (idx > 0) {
       const parentIdx = Math.floor((idx - 1) / 2);
@@ -30,14 +32,14 @@ export default class MinHeap {
     }
   }
 
-  bubbleDown() {
+  bubbleDown(): void {
     let idx = 0;
     const length = this.items.length;
 
     while (true) {
-      let leftIdx = 2 * idx + 1;
-      let rightIdx = 2 * idx + 2;
-      let swapIdx = null;
+      const leftIdx = 2 * idx + 1;
+      const rightIdx = 2 * idx + 2;
+      let swapIdx: number | null = null;
 
       if (leftIdx < length && this.items[leftIdx].nextTrigger < this.items[idx].nextTrigger) {
         swapIdx = leftIdx;
@@ -56,10 +58,10 @@ export default class MinHeap {
     }
   }
 
-  remove(job) {
+  remove(job: T): void {
     const idx = this.items.indexOf(job);
     if (idx === -1) return;
-    const end = this.items.pop();
+    const end = this.items.pop()!;
     if (idx < this.items.length) {
       this.items[idx] = end;
       this.bubbleUp();
@@ -67,7 +69,7 @@ export default class MinHeap {
     }
   }
 
-  isEmpty() {
+  isEmpty(): boolean {
     return this.items.length === 0;
   }
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -4,13 +4,46 @@
  * flat-param recovery, type coercion.
  */
 
+interface RawSchedule {
+  kind?: string;
+  at?: string | number;
+  atMs?: number;
+  everyMs?: string | number;
+  expr?: string;
+  tz?: string;
+}
+
+interface RawPayload {
+  kind?: string;
+  message?: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+interface RawJobInput {
+  name?: string;
+  description?: string;
+  schedule?: RawSchedule;
+  payload?: RawPayload;
+  delivery?: Record<string, unknown>;
+  sessionTarget?: string;
+  wakeMode?: string;
+  enabled?: boolean;
+  deleteAfterRun?: boolean;
+  // flat param recovery
+  job?: RawJobInput;
+  message?: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
 /**
  * Normalize a schedule object. Infers kind from fields if missing.
  */
-export function normalizeSchedule(raw) {
-  if (!raw || typeof raw !== 'object') return raw;
+export function normalizeSchedule(raw: unknown): RawSchedule {
+  if (!raw || typeof raw !== 'object') return raw as RawSchedule;
 
-  const schedule = { ...raw };
+  const schedule: RawSchedule = { ...(raw as RawSchedule) };
 
   // Infer kind from fields if missing
   if (!schedule.kind) {
@@ -24,7 +57,7 @@ export function normalizeSchedule(raw) {
     schedule.kind = schedule.kind.toLowerCase();
   }
 
-  // Legacy: atMs (number) → at (ISO string)
+  // Legacy: atMs (number) -> at (ISO string)
   if (schedule.atMs && !schedule.at) {
     schedule.at = new Date(schedule.atMs).toISOString();
     delete schedule.atMs;
@@ -41,10 +74,10 @@ export function normalizeSchedule(raw) {
 /**
  * Normalize a payload object. Infers kind from fields if missing.
  */
-export function normalizePayload(raw) {
-  if (!raw || typeof raw !== 'object') return raw;
+export function normalizePayload(raw: unknown): RawPayload {
+  if (!raw || typeof raw !== 'object') return raw as RawPayload;
 
-  const payload = { ...raw };
+  const payload: RawPayload = { ...(raw as RawPayload) };
 
   // Infer kind from fields
   if (!payload.kind) {
@@ -71,15 +104,15 @@ const JOB_KEYS = new Set([
   'delivery', 'enabled', 'deleteAfterRun', 'wakeMode',
 ]);
 
-export function recoverFlatParams(params) {
+export function recoverFlatParams(params: RawJobInput): RawJobInput {
   if (params.job && typeof params.job === 'object' && Object.keys(params.job).length > 0) {
     return params.job;
   }
 
-  const synthetic = {};
+  const synthetic: RawJobInput = {};
   for (const key of Object.keys(params)) {
     if (JOB_KEYS.has(key)) {
-      synthetic[key] = params[key];
+      (synthetic as Record<string, unknown>)[key] = params[key];
     }
   }
 
@@ -106,8 +139,8 @@ export function recoverFlatParams(params) {
  * Normalize a complete job input for creation.
  * Applies all normalization: schedule, payload, defaults.
  */
-export function normalizeJobInput(raw) {
-  const job = { ...raw };
+export function normalizeJobInput(raw: RawJobInput): RawJobInput {
+  const job: RawJobInput = { ...raw };
 
   if (job.schedule) {
     job.schedule = normalizeSchedule(job.schedule);
@@ -149,8 +182,8 @@ export function normalizeJobInput(raw) {
 /**
  * Infer a job name from schedule and payload.
  */
-function inferName(job) {
-  const parts = [];
+function inferName(job: RawJobInput): string {
+  const parts: string[] = [];
 
   if (job.schedule?.kind === 'at') parts.push('One-shot');
   else if (job.schedule?.kind === 'every') parts.push('Recurring');

--- a/src/run-log.ts
+++ b/src/run-log.ts
@@ -1,32 +1,45 @@
 /**
  * In-memory run log for job execution history.
  * Stores recent execution results per job with auto-pruning.
- *
- * Persistence (via ORM) is added in PR 2.
  */
 
 const DEFAULT_MAX_ENTRIES_PER_JOB = 100;
 
+export interface RunLogEntry {
+  ts: number;
+  jobId: string;
+  status: string;
+  error?: string;
+  summary?: string;
+  runAtMs?: number;
+  durationMs?: number;
+  nextRunAtMs?: number;
+}
+
+export interface RunLogInput {
+  jobId: string;
+  status: string;
+  error?: string;
+  summary?: string;
+  runAtMs?: number;
+  durationMs?: number;
+  nextRunAtMs?: number;
+}
+
 export default class RunLog {
-  constructor(maxEntriesPerJob = DEFAULT_MAX_ENTRIES_PER_JOB) {
+  maxEntries: number;
+  entries: Map<string, RunLogEntry[]>;
+
+  constructor(maxEntriesPerJob: number = DEFAULT_MAX_ENTRIES_PER_JOB) {
     this.maxEntries = maxEntriesPerJob;
-    this.entries = new Map(); // jobId → RunLogEntry[]
+    this.entries = new Map();
   }
 
   /**
    * Record a job execution result.
-   *
-   * @param {object} entry
-   * @param {string} entry.jobId
-   * @param {"ok"|"error"|"skipped"} entry.status
-   * @param {string} [entry.error]
-   * @param {string} [entry.summary]
-   * @param {number} [entry.runAtMs]
-   * @param {number} [entry.durationMs]
-   * @param {number} [entry.nextRunAtMs]
    */
-  record(entry) {
-    const log = {
+  record(entry: RunLogInput): void {
+    const log: RunLogEntry = {
       ts: Date.now(),
       jobId: entry.jobId,
       status: entry.status,
@@ -41,7 +54,7 @@ export default class RunLog {
       this.entries.set(entry.jobId, []);
     }
 
-    const logs = this.entries.get(entry.jobId);
+    const logs = this.entries.get(entry.jobId)!;
     logs.push(log);
 
     // Auto-prune
@@ -52,12 +65,8 @@ export default class RunLog {
 
   /**
    * Get run history for a job.
-   *
-   * @param {string} jobId
-   * @param {number} [limit=20]
-   * @returns {object[]} Most recent entries, newest first
    */
-  get(jobId, limit = 20) {
+  get(jobId: string, limit: number = 20): RunLogEntry[] {
     const logs = this.entries.get(jobId);
     if (!logs) return [];
     return logs.slice(-limit).reverse();
@@ -66,14 +75,14 @@ export default class RunLog {
   /**
    * Remove all entries for a job.
    */
-  removeJob(jobId) {
+  removeJob(jobId: string): void {
     this.entries.delete(jobId);
   }
 
   /**
    * Clear all entries.
    */
-  clear() {
+  clear(): void {
     this.entries.clear();
   }
 }

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -8,15 +8,15 @@
  */
 import { nextOccurrence, validateCronExpression } from './cron-parser.js';
 
+export interface AtSchedule { kind: 'at'; at: string | number; }
+export interface EverySchedule { kind: 'every'; everyMs: number; anchorMs?: number; }
+export interface CronSchedule { kind: 'cron'; expr: string; tz?: string; }
+export type Schedule = AtSchedule | EverySchedule | CronSchedule;
+
 /**
  * Compute the next run time for a schedule.
- *
- * @param {object} schedule - Schedule definition
- * @param {string} schedule.kind - "at" | "every" | "cron"
- * @param {number} nowMs - Current time in milliseconds
- * @returns {number|undefined} Next run time in ms, or undefined if no future occurrence
  */
-export function computeNextRunAtMs(schedule, nowMs) {
+export function computeNextRunAtMs(schedule: Schedule, nowMs: number): number | undefined {
   if (schedule.kind === 'at') {
     const atMs = typeof schedule.at === 'number' ? schedule.at : Date.parse(schedule.at);
     if (!Number.isFinite(atMs)) return undefined;
@@ -41,15 +41,13 @@ export function computeNextRunAtMs(schedule, nowMs) {
     return nextOccurrence(schedule.expr.trim(), nowSecondMs, tz);
   }
 
-  throw new Error(`Unknown schedule kind: "${schedule.kind}"`);
+  throw new Error(`Unknown schedule kind: "${(schedule as Record<string, unknown>).kind}"`);
 }
 
 /**
  * Validate a schedule definition.
- * @param {object} schedule
- * @throws {Error} if the schedule is invalid
  */
-export function validateSchedule(schedule) {
+export function validateSchedule(schedule: Schedule): void {
   if (!schedule || typeof schedule !== 'object') {
     throw new Error('Schedule must be an object');
   }
@@ -77,5 +75,5 @@ export function validateSchedule(schedule) {
     return;
   }
 
-  throw new Error(`Unknown schedule kind: "${schedule.kind}"`);
+  throw new Error(`Unknown schedule kind: "${(schedule as Record<string, unknown>).kind}"`);
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,14 +1,13 @@
 /**
- * CronService — the main API for advanced job scheduling.
+ * CronService - the main API for advanced job scheduling.
  *
  * Manages jobs in memory with a min-heap for efficient next-job lookup.
- * Supports pluggable store interface (memory-only by default, ORM in PR 2).
  * All state mutations are serialized via async locking.
  */
 import config from 'stonyx/config';
 import log from 'stonyx/log';
-import MinHeap from './min-heap.js';
-import { createJob, updateJob, markRunning, applyResult, isDue } from './job.js';
+import MinHeap, { type HeapItem } from './min-heap.js';
+import { createJob, updateJob, markRunning, applyResult, isDue, type Job, type JobInput, type JobPatch } from './job.js';
 import { computeNextRunAtMs } from './schedule.js';
 import { locked } from './locked.js';
 import { normalizeJobInput, recoverFlatParams } from './normalize.js';
@@ -16,25 +15,64 @@ import RunLog from './run-log.js';
 
 const MAX_TIMER_DELAY_MS = 60_000;
 
+interface HeapEntry extends HeapItem {
+  key: string;
+}
+
+interface JobDueResult {
+  status?: string;
+  error?: string;
+  summary?: string;
+}
+
+interface ExecuteResult {
+  status: string;
+  error?: string;
+  summary?: string;
+  durationMs?: number;
+  deleted?: boolean;
+  reason?: string;
+}
+
+interface ServiceStatus {
+  started: boolean;
+  jobCount: number;
+  nextWakeAtMs: number | undefined;
+}
+
+interface ListOptions {
+  includeDisabled?: boolean;
+}
+
+type OnJobDueCallback = (job: Job) => Promise<JobDueResult | void> | JobDueResult | void;
+
 export default class CronService {
+  jobs: Map<string, Job>;
+  heap: MinHeap<HeapEntry>;
+  timer: ReturnType<typeof setTimeout> | null;
+  running: boolean;
+  runLog: RunLog;
+  started: boolean;
+
+  // Pluggable callbacks for consumers
+  onJobDue: OnJobDueCallback | null;
+
   constructor() {
-    this.jobs = new Map();       // id → job
-    this.heap = new MinHeap();   // ordered by nextRunAtMs
+    this.jobs = new Map();
+    this.heap = new MinHeap();
     this.timer = null;
     this.running = false;
     this.runLog = new RunLog();
     this.started = false;
-
-    // Pluggable callbacks for consumers
-    this.onJobDue = null;        // async (job) => { status, error?, summary? }
+    this.onJobDue = null;
   }
 
-  // ── Lifecycle ──────────────────────────────────────────────
+  // -- Lifecycle -------------------------------------------------------
 
   /**
    * Start the service. Loads jobs from store (if any), arms timer.
    */
-  async start(initialJobs) {
+  async start(initialJobs?: Job[]): Promise<void> {
     if (this.started) return;
     this.started = true;
 
@@ -53,18 +91,18 @@ export default class CronService {
   /**
    * Stop the service. Clears timer.
    */
-  stop() {
+  stop(): void {
     this.started = false;
-    clearTimeout(this.timer);
+    if (this.timer) clearTimeout(this.timer);
     this.timer = null;
   }
 
-  // ── CRUD ───────────────────────────────────────────────────
+  // -- CRUD ------------------------------------------------------------
 
   /**
    * Get service status.
    */
-  status() {
+  status(): ServiceStatus {
     const peek = this.heap.peek();
     return {
       started: this.started,
@@ -76,7 +114,7 @@ export default class CronService {
   /**
    * List jobs, optionally including disabled ones.
    */
-  list(opts) {
+  list(opts?: ListOptions): Job[] {
     const includeDisabled = opts?.includeDisabled ?? false;
     const jobs = [...this.jobs.values()];
     const filtered = includeDisabled ? jobs : jobs.filter(j => j.enabled);
@@ -86,16 +124,16 @@ export default class CronService {
   /**
    * Get a single job by ID.
    */
-  get(id) {
+  get(id: string): Job | null {
     return this.jobs.get(id) || null;
   }
 
   /**
    * Add a new job. Input is normalized for AI compatibility.
    */
-  async add(rawInput) {
+  async add(rawInput: Record<string, unknown>): Promise<Job> {
     return locked(() => {
-      const input = normalizeJobInput(recoverFlatParams(rawInput));
+      const input = normalizeJobInput(recoverFlatParams(rawInput as Record<string, unknown>)) as unknown as JobInput;
       const job = createJob(input);
       this.jobs.set(job.id, job);
 
@@ -111,7 +149,7 @@ export default class CronService {
   /**
    * Update an existing job.
    */
-  async update(id, patch) {
+  async update(id: string, patch: JobPatch): Promise<Job> {
     return locked(() => {
       const job = this.jobs.get(id);
       if (!job) throw new Error(`Job not found: ${id}`);
@@ -136,7 +174,7 @@ export default class CronService {
   /**
    * Remove a job.
    */
-  async remove(id) {
+  async remove(id: string): Promise<void> {
     return locked(() => {
       const job = this.jobs.get(id);
       if (!job) throw new Error(`Job not found: ${id}`);
@@ -150,11 +188,8 @@ export default class CronService {
 
   /**
    * Manually trigger a job.
-   *
-   * @param {string} id - Job ID
-   * @param {"due"|"force"} [mode="force"] - "due" only runs if the job is due, "force" runs regardless
    */
-  async run(id, mode = 'force') {
+  async run(id: string, mode: 'due' | 'force' = 'force'): Promise<ExecuteResult> {
     const job = this.jobs.get(id);
     if (!job) throw new Error(`Job not found: ${id}`);
 
@@ -168,14 +203,14 @@ export default class CronService {
   /**
    * Get run history for a job.
    */
-  runs(id, limit) {
+  runs(id: string, limit?: number): ReturnType<RunLog['get']> {
     return this.runLog.get(id, limit);
   }
 
-  // ── Timer Engine ──────────────────────────────────────��────
+  // -- Timer Engine ----------------------------------------------------
 
-  armTimer() {
-    clearTimeout(this.timer);
+  armTimer(): void {
+    if (this.timer) clearTimeout(this.timer);
     if (!this.started) return;
 
     const peek = this.heap.peek();
@@ -185,9 +220,9 @@ export default class CronService {
     this.timer = setTimeout(() => this.onTimer(), delay);
   }
 
-  async onTimer() {
+  async onTimer(): Promise<void> {
     if (this.running) {
-      // Already processing — re-arm at max delay to prevent scheduler death
+      // Already processing - re-arm at max delay to prevent scheduler death
       this.timer = setTimeout(() => this.onTimer(), MAX_TIMER_DELAY_MS);
       return;
     }
@@ -213,11 +248,11 @@ export default class CronService {
     }
   }
 
-  findDueJobs(nowMs) {
-    const due = [];
+  findDueJobs(nowMs: number): Job[] {
+    const due: Job[] = [];
 
     while (!this.heap.isEmpty()) {
-      const peek = this.heap.peek();
+      const peek = this.heap.peek()!;
       if (peek.nextTrigger > nowMs) break;
 
       this.heap.pop();
@@ -230,11 +265,11 @@ export default class CronService {
     return due;
   }
 
-  async executeJob(job) {
+  async executeJob(job: Job): Promise<ExecuteResult> {
     const startMs = Date.now();
-    let status = 'ok';
-    let error;
-    let summary;
+    let status: string = 'ok';
+    let error: string | undefined;
+    let summary: string | undefined;
 
     try {
       if (this.onJobDue) {
@@ -245,15 +280,15 @@ export default class CronService {
           summary = result.summary;
         }
       }
-    } catch (err) {
+    } catch (err: unknown) {
       status = 'error';
-      error = err?.message || String(err);
+      error = (err as Error)?.message || String(err);
       this.log(`Job "${job.name}" (${job.id}) failed: ${error}`);
     }
 
     const durationMs = Date.now() - startMs;
 
-    applyResult(job, status, error, durationMs);
+    applyResult(job, status as 'ok' | 'error' | 'skipped', error, durationMs);
 
     // Log the run
     this.runLog.record({
@@ -281,14 +316,14 @@ export default class CronService {
     return { status, error, summary, durationMs };
   }
 
-  // ── Helpers ────────────────────────────────────────────────
+  // -- Helpers ---------------------------------------------------------
 
-  removeFromHeap(id) {
+  removeFromHeap(id: string): void {
     // MinHeap doesn't support remove-by-key efficiently,
     // so we rebuild. Fine for typical job counts (< 1000).
-    const remaining = [];
+    const remaining: HeapEntry[] = [];
     while (!this.heap.isEmpty()) {
-      const item = this.heap.pop();
+      const item = this.heap.pop()!;
       if (item.key !== id) remaining.push(item);
     }
     for (const item of remaining) {
@@ -296,8 +331,8 @@ export default class CronService {
     }
   }
 
-  log(message) {
-    if (!config.cron?.log) return;
+  log(message: string): void {
+    if (!(config as Record<string, Record<string, unknown>>).cron?.log) return;
     log.cron(`Cron — ${message}`);
   }
 }

--- a/src/types/stonyx-utils.d.ts
+++ b/src/types/stonyx-utils.d.ts
@@ -1,0 +1,3 @@
+declare module '@stonyx/utils/date' {
+  export function getTimestamp(): number;
+}

--- a/src/types/stonyx.d.ts
+++ b/src/types/stonyx.d.ts
@@ -1,0 +1,14 @@
+declare module 'stonyx/config' {
+  const config: Record<string, unknown>;
+  export default config;
+}
+
+declare module 'stonyx/log' {
+  interface Log {
+    error(message: string, ...args: unknown[]): void;
+    cron(message: string): void;
+    [key: string]: unknown;
+  }
+  const log: Log;
+  export default log;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist-test",
+    "declaration": false,
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- Convert all 9 source files from JavaScript to TypeScript with full strict mode
- Add typed interfaces: `Job`, `JobInput`, `JobPatch`, `JobState`, `Schedule` (union of `AtSchedule`/`EverySchedule`/`CronSchedule`), `RunLogEntry`, `HeapItem`, `ParsedCronExpression`
- Generic `MinHeap<T extends HeapItem>` supports both legacy Cron and CronService heap entries
- Add temporary `.d.ts` declarations for `stonyx` and `@stonyx/utils/date`
- Configure `tsconfig.json` (strict, NodeNext, outDir: dist) and `tsconfig.test.json`
- Update package.json exports (8 sub-modules) with types fields, add build/test scripts

## Test plan
- [x] `pnpm test` passes 138/138 (unit + integration)
- [x] Build produces clean `dist/` output with `.d.ts` declarations for all 8 exports

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)