### PR TITLE
docs: add project-level SME templates

### DIFF
--- a/docs/agents/architect.md
+++ b/docs/agents/architect.md
@@ -1,0 +1,47 @@
+# SME Template: Architect — stonyx-cron
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/architect.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-cron`
+**Framework:** Stonyx module (`@stonyx/cron`) — job scheduling for the Stonyx framework
+**Domain:** Advanced cron/job scheduling with min-heap priority queue, three schedule types (at/every/cron), async locking, error backoff, run history, and pluggable job execution
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (compiled to ESM) |
+| Runtime | Node.js |
+| Framework | Stonyx (runtime dependency) — config, logging |
+| Scheduling | Custom 5-field cron parser with timezone support, interval scheduling, one-shot timestamps |
+| Data Structure | Custom min-heap for O(1) next-job lookup |
+| Build | tsc with dual tsconfig (src + test) |
+| Test | QUnit + Sinon |
+| Package Manager | pnpm |
+
+## Architecture Patterns
+
+- **CronService as the main API:** Not a singleton — consumers instantiate `new CronService()` and manage its lifecycle via `start()` / `stop()`
+- **Min-heap for efficient scheduling:** Jobs are stored in a `MinHeap<HeapEntry>` keyed by `nextTrigger` timestamp — `peek()` always returns the soonest due job in O(1), avoiding full-scan on every timer tick
+- **Three schedule kinds:** `at` (one-shot ISO-8601 or epoch), `every` (recurring interval in ms with optional anchor), `cron` (5-field expression with optional timezone) — each has its own `computeNextRunAtMs` branch
+- **Async locking:** All state mutations (`add`, `update`, `remove`, timer processing) are serialized through `locked()` to prevent race conditions from concurrent async operations
+- **Pluggable execution via `onJobDue` callback:** CronService does not define what a job does — consumers set `service.onJobDue = async (job) => { ... }` to handle execution, keeping the scheduler decoupled from business logic
+- **Error backoff table:** Consecutive failures trigger escalating delays: 30s, 60s, 5m, 15m, 1h — the backoff is applied as `Math.max(normalNext, nowMs + backoff)` so it never shortens the interval
+- **One-shot auto-delete:** Jobs with `deleteAfterRun: true` (default for `at` schedule kind) are removed from the service after successful execution
+- **Auto-disable on schedule errors:** Three consecutive `computeNextRunAtMs` failures disable the job, preventing infinite retry loops on malformed schedules
+- **RunLog for history:** Each execution is recorded with jobId, status, error, summary, runAtMs, durationMs, and nextRunAtMs — the log is per-job with configurable depth
+- **Input normalization:** `normalizeJobInput` and `recoverFlatParams` handle AI-generated inputs that may have flat parameter structures or variant field names
+- **Timer capping:** `MAX_TIMER_DELAY_MS` is 60 seconds — even if the next job is hours away, the timer re-arms at most every 60s to handle newly added jobs and clock drift
+- **Rich subpath exports:** The package exports `./service`, `./cron-parser`, `./schedule`, `./job`, `./normalize`, `./locked`, `./run-log`, and `./min-heap` as independent entry points
+
+## Live Knowledge
+
+- The `stonyx-module` keyword means Stonyx loads this synchronously — `CronService.start()` must be called explicitly by the consumer, not by the framework lifecycle
+- `removeFromHeap` rebuilds the heap by popping all items and re-pushing non-matching ones — this is O(n log n) but acceptable for typical job counts under 1000
+- The `running` flag prevents re-entrant timer execution — if `onTimer` is already processing, the next tick just re-arms at `MAX_TIMER_DELAY_MS` and returns
+- The cron parser is fully custom with zero dependencies — it supports wildcards, ranges, steps, lists, and month/day name aliases; timezone support uses `Intl.DateTimeFormat` for locale-aware field matching
+- `Job.sessionTarget` and `Job.wakeMode` are scheduling metadata consumed by Beatrix — the cron service itself does not interpret them
+- `computeNextRunAtMs` for `every` schedules uses an anchor-based calculation to prevent drift: `anchor + ceil((now - anchor) / interval) * interval`

--- a/docs/agents/qa-test-engineer.md
+++ b/docs/agents/qa-test-engineer.md
@@ -1,0 +1,41 @@
+# SME Template: QA Test Engineer — stonyx-cron
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/qa-test-engineer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-cron`
+**Framework:** Stonyx module (`@stonyx/cron`) — job scheduling for the Stonyx framework
+**Domain:** Advanced cron/job scheduling with min-heap priority queue, three schedule types (at/every/cron), async locking, error backoff, run history, and pluggable execution
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (compiled to ESM) |
+| Test Framework | QUnit |
+| Mocking | Sinon (especially fake timers for timer-based tests) |
+| Build | tsc with separate `tsconfig.test.json` |
+| Test Runner | `stonyx test` CLI |
+| CI | GitHub Actions (`ci.yml`) |
+
+## Architecture Patterns
+
+- **Test build pipeline:** Tests compile to `dist-test/` via `tsconfig.test.json`, then run with `stonyx test 'dist-test/test/**/*-test.js'`
+- **Integration tests available:** `test/integration/` tests the full CronService lifecycle — start, add jobs, timer fires, execute, re-schedule
+- **Sample handler files:** `test/sample/` contains sample job definitions and configs
+- **Fake timers essential:** Sinon fake timers are critical for testing `armTimer`, `onTimer`, and the heartbeat-like scheduling loop — real timers make tests slow and flaky
+- **Pure function testability:** `computeNextRunAtMs`, `validateSchedule`, `parseCronExpression`, `parseField`, `nextOccurrence`, `errorBackoffMs`, `isDue`, `createJob`, and `normalizeJobInput` are all pure functions testable without any service setup
+- **MinHeap tested independently:** The min-heap is exported as `@stonyx/cron/min-heap` and has its own focused test coverage — push, pop, peek, remove, ordering invariants
+
+## Live Knowledge
+
+- `CronService` is NOT a singleton — tests can create fresh instances without cleanup, unlike the singleton modules
+- The `locked()` utility serializes async operations — tests that call `add()` / `update()` / `remove()` concurrently should verify that operations don't interleave
+- Cron expression parsing must handle edge cases: month/day names (case-insensitive), day-of-week 7→0 normalization, wildcards with steps, and the OR semantics when both day-of-month and day-of-week are restricted
+- `nextOccurrence` has a 4-year search limit — test that expressions with no valid future match within 4 years return `undefined`
+- Error backoff values are `[30000, 60000, 300000, 900000, 3600000]` — test that `consecutiveErrors` beyond 5 caps at 3600000ms
+- The `recoverFlatParams` normalizer handles AI-generated inputs with flat keys like `scheduleCron` instead of nested `schedule.kind: 'cron'` — test these recovery paths
+- `applyResult` auto-disables `at`-kind jobs after any terminal status — test that both success and error disable them
+- The timer re-arms even during `running` state to prevent scheduler death — test the re-entrancy guard by having `onJobDue` trigger another timer tick

--- a/docs/agents/validation-loop-team.md
+++ b/docs/agents/validation-loop-team.md
@@ -1,0 +1,40 @@
+# SME Template: Validation Loop Team — stonyx-cron
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/validation-loop-team.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-cron`
+**Framework:** Stonyx module (`@stonyx/cron`) — job scheduling for the Stonyx framework
+**Domain:** Advanced cron/job scheduling with min-heap priority queue, three schedule types (at/every/cron), async locking, error backoff, run history, and pluggable execution
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (compiled to ESM) |
+| Runtime | Node.js |
+| Data Structure | Custom min-heap |
+| Scheduling | Custom cron parser + interval/one-shot |
+| Test | QUnit + Sinon |
+| Build | tsc (src → dist, test → dist-test) |
+
+## Architecture Patterns
+
+- **Min-heap invariant is the scheduling backbone:** The heap must always have the earliest `nextTrigger` at index 0 — validation must confirm that `push`, `pop`, and `remove` maintain the heap property under all mutation sequences
+- **Schedule computation correctness:** `computeNextRunAtMs` must always return a time strictly in the future (or undefined for expired one-shots) — validation should test boundary conditions: exactly-on-time, one-ms-before, one-ms-after, and timezone transitions (DST)
+- **Async lock serialization:** All CRUD operations and timer processing go through `locked()` — validation must confirm that concurrent calls do not corrupt `jobs` Map or `heap` state
+- **Error backoff escalation:** Backoff must escalate on consecutive errors and reset on success — validate the full sequence: 30s → 60s → 5m → 15m → 1h → stays at 1h
+- **Auto-disable after 3 schedule errors:** `scheduleErrorCount` increments on `computeNextRunAtMs` failure and disables the job at 3 — validation should confirm the counter resets when the schedule is updated
+- **One-shot lifecycle:** `at`-kind jobs must be disabled after execution and auto-deleted if `deleteAfterRun` is true — validation must confirm no heap entry remains after deletion
+- **Timer capping at 60 seconds:** Even with a far-future next job, the timer re-arms at most 60s out — validation should confirm that a job added while the timer is sleeping for 60s gets picked up on the next tick
+
+## Live Knowledge
+
+- `removeFromHeap` is O(n log n) via full rebuild — this is acceptable for typical workloads but validation should note it as a scaling concern if job counts exceed expectations
+- The `running` guard prevents re-entrant `onTimer` execution but re-arms at `MAX_TIMER_DELAY_MS` — validation should confirm the scheduler cannot die if `onJobDue` takes longer than 60 seconds
+- `findDueJobs` pops items from the heap and only re-inserts them in `executeJob` after updating `nextRunAtMs` — if `executeJob` throws before re-insert, the job is lost from the heap; validation should confirm error handling covers this
+- The cron parser treats both day-of-month and day-of-week restricted (non-wildcard) as OR — matching either satisfies the day check; this follows traditional cron semantics
+- `Job.id` is generated via `crypto.randomUUID()` — there is no deduplication check; validation should treat duplicate names as valid (different IDs)
+- `normalizeJobInput` is a defensive layer for AI-generated inputs — it converts flat params, coerces types, and applies defaults; validation should test malformed inputs that a human would never produce but an LLM might


### PR DESCRIPTION
## Summary
- Add `docs/agents/` directory with project-specific SME templates for architect, qa-test-engineer, and validation-loop-team roles
- Each template inherits from the base template in beatrix-shared and layers stonyx-cron-specific context (CronService API, min-heap scheduling, three schedule kinds, custom cron parser, error backoff, async locking, run history, input normalization)

## Test plan
- [ ] Verify all 3 templates follow the required format (header, inheritance note, project context, tech stack, architecture patterns, live knowledge)
- [ ] Confirm content accurately reflects the actual codebase architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)