### PR TITLE
fix(config): ship config/environment.js not .ts (#30)

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,0 +1,6 @@
+const { CRON_LOG } = process;
+
+export default {
+  log: CRON_LOG ?? true,
+  logColor: '#888',
+}

--- a/config/environment.ts
+++ b/config/environment.ts
@@ -1,6 +1,0 @@
-const { CRON_LOG } = process as unknown as Record<string, unknown>;
-
-export default {
-  log: CRON_LOG ?? true,
-  logColor: '#888',
-}

--- a/test/unit/publish-surface-test.ts
+++ b/test/unit/publish-surface-test.ts
@@ -1,0 +1,35 @@
+// Regression test for stonyx-cron#30.
+//
+// The package must publish `config/environment.js` (plain JS) and must NOT
+// publish `config/environment.ts`. Node refuses to type-strip inside
+// `node_modules`, so if we ship a `.ts` here the stonyx module loader
+// dynamic-import of this config will crash consumers at parse time.
+//
+// This test invokes `npm pack --dry-run --json` and asserts the tarball
+// entry list contains `config/environment.js` and does not contain
+// `config/environment.ts`.
+import QUnit from 'qunit';
+import { execFileSync } from 'child_process';
+
+const { module, test } = QUnit;
+
+module('[Unit] Publish surface', function () {
+  test('config/environment.js is published and .ts is not', function (assert) {
+    const stdout = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+    const report = JSON.parse(stdout);
+    const entry = Array.isArray(report) ? report[0] : report;
+    const files = (entry.files ?? []).map((f: { path: string }) => f.path);
+
+    assert.ok(
+      files.includes('config/environment.js'),
+      'published tarball includes config/environment.js'
+    );
+    assert.notOk(
+      files.includes('config/environment.ts'),
+      'published tarball does NOT include config/environment.ts'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Rename `config/environment.ts` to `config/environment.js` and strip the type-only assertion (`process as unknown as Record<string, unknown>`). Runtime semantics unchanged.
- Bump patch version `0.2.1-beta.56` -> `0.2.1-beta.57`.
- Add regression test (`test/unit/publish-surface-test.ts`) that runs `npm pack --dry-run --json` and asserts the published tarball contains `config/environment.js` and does NOT contain `config/environment.ts`.

## Why

Closes abofs/stonyx-cron#30.

Node refuses to type-strip sources inside `node_modules`, so shipping `config/environment.ts` crashes consumers at parse time when the stonyx module loader dynamic-imports the config. This is the same class of bug as the parent P0 hotfix for the already-promoted `latest`-channel module (stonyx-orm#118); this PR applies the fix on the beta channel before any promotion.

The `.ts` extension was introduced as scope-creep in the "migrate tests to TypeScript" PR (was #25). This file has always been effectively JS — the only TS construct was a single cast that stripping restores to valid JS.

## Test plan

- [x] `pnpm test` — all 139 tests pass, including the new publish-surface assertion
- [x] `node --check config/environment.js` — valid JS
- [x] Verified renamed file is tracked at `config/environment.js` and `config/environment.ts` no longer exists in the tree