### PR TITLE
fix(cron): self-register cron log type in new Cron.init

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,13 @@ export default class Cron {
     Cron.instance = this;
   }
 
+  async init(): Promise<void> {
+    // Self-register so log.cron works even when @stonyx/cron is in the
+    // consumer's `dependencies` (stonyx loader only merges devDependencies).
+    const { logColor = '#888', logMethod = 'cron' } = config.cron ?? {};
+    log.defineType(logMethod, logColor);
+  }
+
   scheduleNextRun(): void {
     if (this.timer) clearTimeout(this.timer);
 

--- a/src/types/stonyx.d.ts
+++ b/src/types/stonyx.d.ts
@@ -1,6 +1,8 @@
 declare module 'stonyx/config' {
   interface CronConfig {
     log?: boolean;
+    logColor?: string;
+    logMethod?: string;
   }
   interface Config {
     cron: CronConfig;
@@ -15,6 +17,7 @@ declare module 'stonyx/log' {
   interface Log {
     error(message: string, ...args: unknown[]): void;
     cron(message: string): void;
+    defineType(type: string, setting: string, options?: Record<string, unknown> | null): void;
     [key: string]: unknown;
   }
   const log: Log;

--- a/test/unit/cron-test.ts
+++ b/test/unit/cron-test.ts
@@ -94,4 +94,29 @@ module('[Unit] Cron', function (hooks) {
 
     assert.ok(stub.calledWithMatch(sinon.match(/Cron job "jobErr" failed:/)), 'Error logged');
   });
+
+  module('self-registers log type in init() (#32)', function (innerHooks) {
+    innerHooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    test('registers cron log type on init', async function (assert) {
+      assert.strictEqual(typeof log.defineType, 'function', 'log.defineType is available');
+
+      const c = new Cron();
+      await c.init();
+
+      assert.strictEqual(typeof log.cron, 'function', 'log.cron is callable after init');
+    });
+
+    test('idempotent: calling init twice does not throw', async function (assert) {
+      const c1 = new Cron();
+      await c1.init();
+
+      const c2 = new Cron();
+      await c2.init();
+
+      assert.strictEqual(typeof log.cron, 'function', 'log.cron still callable after second init');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements the per-module rollout decided in abofs/stonyx#75, following the precedent set by abofs/stonyx-sockets#30. When a consumer places `@stonyx/cron` in `dependencies` instead of `devDependencies`, the stonyx loader filters it out and `log.cron` is never registered — calling it throws `is not a function`. Self-registering defensively makes the module independently correct regardless of placement.

Closes #32.

## Changes

- **`src/main.ts`** — adds a **new** `async init(): Promise<void>` method to the `Cron` class. `Cron` had no `init()` before this change; the method is introduced specifically as the canonical self-registration site, matching the shape used by siblings. Its only statement is `log.defineType(logMethod, logColor)` with literal fallbacks matching `config/environment.js` (`logColor: '#888'`, `logMethod: 'cron'` via module-name fallback).
- **`src/types/stonyx.d.ts`** — extends `CronConfig` with `logColor?` / `logMethod?`, and adds `defineType` to the `Log` interface.
- **`test/unit/cron-test.ts`** — two unit tests mirroring stonyx-sockets#30: registration on init, idempotence on repeat init.

## Deliberately NOT changed

The `stonyx-async` keyword was **not** added to `package.json`. Cron is intentionally synchronous and the refinement on stonyx#75 explicitly excluded this change. The loader treats missing/uncalled init as a no-op today; the new `init()` is available for consumers that instantiate `Cron` manually, establishes the canonical site, and makes a future `stonyx-async` opt-in a one-line follow-up.

## Cross-links

- abofs/stonyx#75 — architectural decision + full rationale
- abofs/stonyx-sockets#30 — precedent PR

## Test plan

- [x] `pnpm install`
- [x] `pnpm build` passes
- [ ] CI runs full test suite (local `pnpm test` skipped per beta<62 worktree hang pattern)